### PR TITLE
Remove legacy copyright notices.

### DIFF
--- a/sonic/private/pas_data_store.h
+++ b/sonic/private/pas_data_store.h
@@ -15,17 +15,6 @@
  */
 
 /*********************************************************************
- * LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
- *
- * This source code is confidential, proprietary, and contains trade
- * secrets that are the sole property of Dell Inc.
- * Copy and/or distribution of this source code or disassembly or reverse
- * engineering of the resultant object code are strictly forbidden without
- * the written consent of Dell Inc.
- *
-*********************************************************************/
-
-/*********************************************************************
  * @file pas_data_store.h
  * @brief This file contains function prototypes to access 
  *        pas data store.

--- a/sonic/private/pas_fuse_common.h
+++ b/sonic/private/pas_fuse_common.h
@@ -14,17 +14,6 @@
  * permissions and limitations under the License.
  */
 
-
-/*********************************************************************
- * LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
- *
- * This source code is confidential, proprietary, and contains trade
- * secrets that are the sole property of Dell Inc.
- * Copy and/or distribution of this source code or disassembly or reverse
- * engineering of the resultant object code are strictly forbidden without
- * the written consent of Dell Inc.
- *
- *********************************************************************/
 /**
  * file : pas_fuse_common.h
  * brief: pas daemon interface layer to SDI API

--- a/sonic/private/pas_fuse_handlers.h
+++ b/sonic/private/pas_fuse_handlers.h
@@ -14,23 +14,12 @@
  * permissions and limitations under the License.
  */
 
-/*********************************************************************
- * LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
- *
- * This source code is confidential, proprietary, and contains trade
- * secrets that are the sole property of Dell Inc.
- * Copy and/or distribution of this source code or disassembly or reverse
- * engineering of the resultant object code are strictly forbidden without
- * the written consent of Dell Inc.
- *
- *********************************************************************/
 /**
  * file : pas_fuse_handlers.h
  * brief: pas daemon interface layer to SDI API
  * date : 04/2015
  *
  */
-/* Copyright (c) 2015, Dell Inc. All Rights Reserved */
 
 #ifndef __PAS_FUSE_HANDLERS_H
 #define __PAS_FUSE_HANDLERS_H

--- a/sonic/private/pas_media.h
+++ b/sonic/private/pas_media.h
@@ -15,17 +15,6 @@
  */
 
 /*********************************************************************
- * LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
- *
- * This source code is confidential, proprietary, and contains trade
- * secrets that are the sole property of Dell Inc.
- * Copy and/or distribution of this source code or disassembly or reverse
- * engineering of the resultant object code are strictly forbidden without
- * the written consent of Dell Inc.
- *
-*********************************************************************/
-
-/*********************************************************************
  * @file pas_media.h
  * @brief This file contains the structure definitions of all the 
  *        physical media handling and function declarations.

--- a/sonic/private/pas_media_sdi_wrapper.h
+++ b/sonic/private/pas_media_sdi_wrapper.h
@@ -14,17 +14,6 @@
  * permissions and limitations under the License.
  */
 
-/***************************************************************************
-* LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-*
-* This source code is confidential, proprietary, and contains trade
-* secrets that are the sole property of Dell Inc.
-* Copy and/or distribution of this source code or disassembly or reverse
-* engineering of the resultant object code are strictly forbidden without
-* the written consent of Dell Inc.
-*
-**************************************************************************/
-
 /**************************************************************************
 * @file pas_media_sdi_wrapper.h
 *

--- a/sonic/private/pas_res_structs.h
+++ b/sonic/private/pas_res_structs.h
@@ -15,17 +15,6 @@
  */
 
 /*********************************************************************
- * LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
- *
- * This source code is confidential, proprietary, and contains trade
- * secrets that are the sole property of Dell Inc.
- * Copy and/or distribution of this source code or disassembly or reverse
- * engineering of the resultant object code are strictly forbidden without
- * the written consent of Dell Inc.
- *
-*********************************************************************/
-
-/*********************************************************************
  * @file pas_res_structs.h
  * @brief This file contains the structure definitions of all the 
  *        system resources.

--- a/src/fuse/pas_fuse_common.c
+++ b/src/fuse/pas_fuse_common.c
@@ -14,16 +14,6 @@
  * permissions and limitations under the License.
  */
 
-/*********************************************************************
- * LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
- *
- * This source code is confidential, proprietary, and contains trade
- * secrets that are the sole property of Dell Inc.
- * Copy and/or distribution of this source code or disassembly or reverse
- * engineering of the resultant object code are strictly forbidden without
- * the written consent of Dell Inc.
- *
- *********************************************************************/
 /**
  * file  : pas_fuse_common_sdi.c
  * brief : Dell Networking PAS (Physical Access Layer) SDI (System Device

--- a/src/fuse/pas_fuse_diag_mode.c
+++ b/src/fuse/pas_fuse_diag_mode.c
@@ -14,16 +14,6 @@
  * permissions and limitations under the License.
  */
 
-/*********************************************************************
- * LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
- *
- * This source code is confidential, proprietary, and contains trade
- * secrets that are the sole property of Dell Inc.
- * Copy and/or distribution of this source code or disassembly or reverse
- * engineering of the resultant object code are strictly forbidden without
- * the written consent of Dell Inc.
- *
- *********************************************************************/
 /**
  * file : pas_fuse_diag_mode.c
  * brief: pas daemon interface layer to display_led SDI API

--- a/src/fuse/pas_fuse_display_led.c
+++ b/src/fuse/pas_fuse_display_led.c
@@ -14,16 +14,6 @@
  * permissions and limitations under the License.
  */
 
-/*********************************************************************
- * LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
- *
- * This source code is confidential, proprietary, and contains trade
- * secrets that are the sole property of Dell Inc.
- * Copy and/or distribution of this source code or disassembly or reverse
- * engineering of the resultant object code are strictly forbidden without
- * the written consent of Dell Inc.
- *
- *********************************************************************/
 /**
  * file : pas_fuse_display_led.c
  * brief: pas daemon interface layer to display_led SDI API

--- a/src/fuse/pas_fuse_entity_info.c
+++ b/src/fuse/pas_fuse_entity_info.c
@@ -14,16 +14,6 @@
  * permissions and limitations under the License.
  */
 
-/*********************************************************************
- * LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
- *
- * This source code is confidential, proprietary, and contains trade
- * secrets that are the sole property of Dell Inc.
- * Copy and/or distribution of this source code or disassembly or reverse
- * engineering of the resultant object code are strictly forbidden without
- * the written consent of Dell Inc.
- *
- *********************************************************************/
 /**
  * file : pas_fuse_entity_info.c
  * brief: pas daemon interfthe layer to entity_info SDI API

--- a/src/fuse/pas_fuse_fan.c
+++ b/src/fuse/pas_fuse_fan.c
@@ -14,16 +14,6 @@
  * permissions and limitations under the License.
  */
 
-/*********************************************************************
- * LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
- *
- * This source code is confidential, proprietary, and contains trade
- * secrets that are the sole property of Dell Inc.
- * Copy and/or distribution of this source code or disassembly or reverse
- * engineering of the resultant object code are strictly forbidden without
- * the written consent of Dell Inc.
- *
- *********************************************************************/
 /**
  * file : pas_fuse_fan.c
  * brief: pas daemon interface layer to fan SDI API

--- a/src/fuse/pas_fuse_led.c
+++ b/src/fuse/pas_fuse_led.c
@@ -14,16 +14,6 @@
  * permissions and limitations under the License.
  */
 
-/*********************************************************************
- * LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
- *
- * This source code is confidential, proprietary, and contains trade
- * secrets that are the sole property of Dell Inc.
- * Copy and/or distribution of this source code or disassembly or reverse
- * engineering of the resultant object code are strictly forbidden without
- * the written consent of Dell Inc.
- *
- *********************************************************************/
 /**
  * file : pas_fuse_led.c
  * brief: pas daemon interface layer to led SDI API

--- a/src/fuse/pas_fuse_main.c
+++ b/src/fuse/pas_fuse_main.c
@@ -14,16 +14,6 @@
  * permissions and limitations under the License.
  */
 
-/*********************************************************************
- * LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
- *
- * This source code is confidential, proprietary, and contains trade
- * secrets that are the sole property of Dell Inc.
- * Copy and/or distribution of this source code or disassembly or reverse
- * engineering of the resultant object code are strictly forbidden without
- * the written consent of Dell Inc.
- *
- *********************************************************************/
 /*
  * filename: pas_fuse_main.c
  */

--- a/src/fuse/pas_fuse_media.c
+++ b/src/fuse/pas_fuse_media.c
@@ -14,16 +14,6 @@
  * permissions and limitations under the License.
  */
 
-/*********************************************************************
- * LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
- *
- * This source code is confidential, proprietary, and contains trade
- * secrets that are the sole property of Dell Inc.
- * Copy and/or distribution of this source code or disassembly or reverse
- * engineering of the resultant object code are strictly forbidden without
- * the written consent of Dell Inc.
- *
- *********************************************************************/
 /**
  * file : pas_fuse_media.c
  * brief: pas daemon interfthe layer to entity_info SDI API

--- a/src/fuse/pas_fuse_parser.c
+++ b/src/fuse/pas_fuse_parser.c
@@ -14,16 +14,6 @@
  * permissions and limitations under the License.
  */
 
-/*********************************************************************
- * LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
- *
- * This source code is confidential, proprietary, and contains trade
- * secrets that are the sole property of Dell Inc.
- * Copy and/or distribution of this source code or disassembly or reverse
- * engineering of the resultant object code are strictly forbidden without
- * the written consent of Dell Inc.
- *
- *********************************************************************/
 /**
  * file  : pas_fuse_parser.c
  * brief : FUSE realtime parser function to parse paths into valid SDI read/write function calls.

--- a/src/fuse/pas_fuse_thermal_sensor.c
+++ b/src/fuse/pas_fuse_thermal_sensor.c
@@ -14,16 +14,6 @@
  * permissions and limitations under the License.
  */
 
-/*********************************************************************
- * LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
- *
- * This source code is confidential, proprietary, and contains trade
- * secrets that are the sole property of Dell Inc.
- * Copy and/or distribution of this source code or disassembly or reverse
- * engineering of the resultant object code are strictly forbidden without
- * the written consent of Dell Inc.
- *
-*********************************************************************/
 /**
  * file : pas_fuse_thermal_sensor.c
  * brief: pas daemon interface layer to thermal_sensor SDI API

--- a/src/pas/pas_media_channel_handler.c
+++ b/src/pas/pas_media_channel_handler.c
@@ -14,17 +14,6 @@
  * permissions and limitations under the License.
  */
 
-/***************************************************************************
- * LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
- *
- * This source code is confidential, proprietary, and contains trade
- * secrets that are the sole property of Dell Inc.
- * Copy and/or distribution of this source code or disassembly or reverse
- * engineering of the resultant object code are strictly forbidden without
- * the written consent of Dell Inc.
- *
- ***************************************************************************/
-
 /**************************************************************************
  * @file pas_media_channel_handler.c
  * 

--- a/src/pas/pas_media_config_handler.c
+++ b/src/pas/pas_media_config_handler.c
@@ -14,17 +14,6 @@
  * permissions and limitations under the License.
  */
 
-/***************************************************************************
- * LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
- *
- * This source code is confidential, proprietary, and contains trade
- * secrets that are the sole property of Dell Inc.
- * Copy and/or distribution of this source code or disassembly or reverse
- * engineering of the resultant object code are strictly forbidden without
- * the written consent of Dell Inc.
- *
- ***************************************************************************/
-
 /**************************************************************************
  * @file pas_media_config_handler.c
  *

--- a/src/pas/pas_media_handler.c
+++ b/src/pas/pas_media_handler.c
@@ -14,17 +14,6 @@
  * permissions and limitations under the License.
  */
 
-/***************************************************************************
- * LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
- *
- * This source code is confidential, proprietary, and contains trade
- * secrets that are the sole property of Dell Inc.
- * Copy and/or distribution of this source code or disassembly or reverse
- * engineering of the resultant object code are strictly forbidden without
- * the written consent of Dell Inc.
- *
- ***************************************************************************/
-
 /**************************************************************************
  * @file pas_media_handler.c
  *

--- a/src/pas_data_store.cpp
+++ b/src/pas_data_store.cpp
@@ -14,17 +14,6 @@
  * permissions and limitations under the License.
  */
 
-/***************************************************************************
- * LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
- *
- * This source code is confidential, proprietary, and contains trade
- * secrets that are the sole property of Dell Inc.
- * Copy and/or distribution of this source code or disassembly or reverse
- * engineering of the resultant object code are strictly forbidden without
- * the written consent of Dell Inc.
- *
- **************************************************************************/
-
 /**
  * @file pas_data_store.cpp
  *

--- a/src/pas_media.c
+++ b/src/pas_media.c
@@ -14,17 +14,6 @@
  * permissions and limitations under the License.
  */
 
-/***************************************************************************
-* LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-*
-* This source code is confidential, proprietary, and contains trade
-* secrets that are the sole property of Dell Inc.
-* Copy and/or distribution of this source code or disassembly or reverse
-* engineering of the resultant object code are strictly forbidden without
-* the written consent of Dell Inc.
-*
-**************************************************************************/
-
 /**************************************************************************
 * @file pas_media.c
 *

--- a/src/pas_media_utils.c
+++ b/src/pas_media_utils.c
@@ -14,17 +14,6 @@
  * permissions and limitations under the License.
  */
 
-/***************************************************************************
- * LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
- *
- * This source code is confidential, proprietary, and contains trade
- * secrets that are the sole property of Dell Inc.
- * Copy and/or distribution of this source code or disassembly or reverse
- * engineering of the resultant object code are strictly forbidden without
- * the written consent of Dell Inc.
- *
- ***************************************************************************/
-
 /**************************************************************************
  * @file pas_media_utils.c
  *

--- a/src/pas_utils.c
+++ b/src/pas_utils.c
@@ -14,17 +14,6 @@
  * permissions and limitations under the License.
  */
 
-/***************************************************************************
- * LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
- *
- * This source code is confidential, proprietary, and contains trade
- * secrets that are the sole property of Dell Inc.
- * Copy and/or distribution of this source code or disassembly or reverse
- * engineering of the resultant object code are strictly forbidden without
- * the written consent of Dell Inc.
- *
- **************************************************************************/
-
 /**
  * @file pas_utils.c
  *


### PR DESCRIPTION
Due to subtle differences in formatting, there were a few cases where
the former Dell copyright notice was not removed at the time the open
source copyright notice was added.