### PR TITLE
Use AC_CONFIG_MACRO_DIRS / ACLOCAL_AMFLAGS.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,4 @@
+ACLOCAL_AMFLAGS=-I m4
 
 bin_SCRIPTS = scripts/*
 

--- a/configure.ac
+++ b/configure.ac
@@ -6,6 +6,7 @@ AC_INIT([sonic_pas], [1.0.1], [sonicproject@gmail.com])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_SRCDIR([config.h.in])
 AC_CONFIG_HEADERS([config.h])
+AC_CONFIG_MACRO_DIRS([m4])
 #AC_CHECK_HEADERS([libxml/parser.h])
 
 # Checks for programs.


### PR DESCRIPTION
Avoid configure / libtool warnings by specifying directory for m4 macros.